### PR TITLE
Fix Travis fail for libraries using regex

### DIFF
--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -41,8 +41,9 @@ then
   install-ponyc-master
   popd
 else
-  echo -e "\033[0;32mInstalling latest ponyc release\033[0m"
+  echo "Installing ponyc runtime dependencies..."
   download_pcre
+  echo -e "\033[0;32mInstalling latest ponyc release\033[0m"
   sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "D401AB61 DBE1D0A2"
   echo "deb https://dl.bintray.com/pony-language/ponyc-debian pony-language main" | sudo tee -a /etc/apt/sources.list
   sudo apt-get update

--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -42,6 +42,7 @@ then
   popd
 else
   echo -e "\033[0;32mInstalling latest ponyc release\033[0m"
+  download_pcre
   sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "D401AB61 DBE1D0A2"
   echo "deb https://dl.bintray.com/pony-language/ponyc-debian pony-language main" | sudo tee -a /etc/apt/sources.list
   sudo apt-get update


### PR DESCRIPTION
When running tests on a library with `use "regex"`, they may pass locally if the library is installed, but fail on Travis in the linking step due to "undefined references to pcre2".

[Example.](https://travis-ci.org/EpicEric/pony-mqtt/builds/295242567)

Telling the bash script to always download and build PCRE2 fixes this issue.